### PR TITLE
using u and mu in the same equation reduces readability

### DIFF
--- a/BA4/NotesCours/ProbabilityAndStatistics/Lecture16/lecture16.tex
+++ b/BA4/NotesCours/ProbabilityAndStatistics/Lecture16/lecture16.tex
@@ -170,7 +170,7 @@
     Let $X \followsdistr N_p\left(\mu, \Omega\right)$. We have the following properties:
     \begin{enumerate}
         \item The moment-generating function of $X$ is: 
-        \[M_X\left(u\right) = \exp\left(u^T \mu + \frac{1}{2} u^T \Omega u\right), \mathspace u \in \mathbb{R}^p\]
+        \[M_X\left(t\right) = \exp\left(t^T \mu + \frac{1}{2} t^T \Omega t\right), \mathspace t \in \mathbb{R}^p\]
         \item Let $\mathcal{A}, \mathcal{B} \subset \left\{1, \ldots, p\right\}$ be such that $\mathcal{A} \cap \mathcal{B} = \o$. $X_{\mathcal{A}}$ and $X_{\mathcal{B}}$ are independent ($X_{\mathcal{A}} \independent X_{\mathcal{B}}$) if and only if: 
         \[\Omega_{\mathcal{A}\times\mathcal{B}} = 0\]
 


### PR DESCRIPTION
Je trouve que ça pourrait réduire une potentielle confusion 