### PR TITLE
Fix: analyse 3 lecture 8, remplacer 2 avec z dans l'example 1

### DIFF
--- a/BA3/NotesCours/Analyse-3/Lecture08/lecture08.tex
+++ b/BA3/NotesCours/Analyse-3/Lecture08/lecture08.tex
@@ -138,7 +138,7 @@
         \[\sigma_z = \begin{pmatrix} \cos\left(\theta\right) \\ \sin\left(\theta\right) \\ 1 \end{pmatrix}, \sigma_{\theta} = \begin{pmatrix} -z\sin\left(\theta\right) \\ z\cos\left(\theta\right) \\ 0 \end{pmatrix} \implies \sigma_z \wedge \sigma_{\theta} = \begin{pmatrix} -z\cos\left(\theta\right) \\ -z\sin\left(\theta\right) \\ z \end{pmatrix} \]
 
         Nous n'avons pas besoin de regarder sa direction, tant que nous réutiliserons cette paramétrisation ensuite (et, de toute façon, il n'y a pas vraiment de direction meilleure qu'une autre). Nous pouvons donc calculer notre intégrale: 
-        \autoeq{\iint_{\Sigma} \left(\rot F\right) \dotprod dS = \int_{0}^{1} \int_{0}^{2\pi} \left(1, 1, 1\right) \dotprod \left(-2\cos\left(\theta\right), -2\sin\left(\theta\right), z\right) d \theta dz = \int_{0}^{1} \int_{0}^{2\pi} \left(-2\cos\left(\theta\right) - 2\sin\left(\theta\right) + z\right) d \theta dz = \int_{0}^{1} 2\pi z dz = 2\pi \frac{1}{2} = \pi}
+                \autoeq{\iint_{\Sigma} \left(\rot F\right) \dotprod dS = \int_{0}^{1} \int_{0}^{2\pi} \left(1, 1, 1\right) \dotprod \left(-z\cos\left(\theta\right), -z\sin\left(\theta\right), z\right) d \theta dz = \int_{0}^{1} \int_{0}^{2\pi} \left(-z\cos\left(\theta\right) - z\sin\left(\theta\right) + z\right) d \theta dz = \int_{0}^{1} 2\pi z dz = 2\pi \frac{1}{2} = \pi}
     \end{subparag}
 
     \begin{subparag}{Paramétrisation du bord}

--- a/BA3/NotesCours/Analyse-3/Lecture08/lecture08.tex
+++ b/BA3/NotesCours/Analyse-3/Lecture08/lecture08.tex
@@ -138,7 +138,7 @@
         \[\sigma_z = \begin{pmatrix} \cos\left(\theta\right) \\ \sin\left(\theta\right) \\ 1 \end{pmatrix}, \sigma_{\theta} = \begin{pmatrix} -z\sin\left(\theta\right) \\ z\cos\left(\theta\right) \\ 0 \end{pmatrix} \implies \sigma_z \wedge \sigma_{\theta} = \begin{pmatrix} -z\cos\left(\theta\right) \\ -z\sin\left(\theta\right) \\ z \end{pmatrix} \]
 
         Nous n'avons pas besoin de regarder sa direction, tant que nous réutiliserons cette paramétrisation ensuite (et, de toute façon, il n'y a pas vraiment de direction meilleure qu'une autre). Nous pouvons donc calculer notre intégrale: 
-                \autoeq{\iint_{\Sigma} \left(\rot F\right) \dotprod dS = \int_{0}^{1} \int_{0}^{2\pi} \left(1, 1, 1\right) \dotprod \left(-z\cos\left(\theta\right), -z\sin\left(\theta\right), z\right) d \theta dz = \int_{0}^{1} \int_{0}^{2\pi} \left(-z\cos\left(\theta\right) - z\sin\left(\theta\right) + z\right) d \theta dz = \int_{0}^{1} 2\pi z dz = 2\pi \frac{1}{2} = \pi}
+        \autoeq{\iint_{\Sigma} \left(\rot F\right) \dotprod dS = \int_{0}^{1} \int_{0}^{2\pi} \left(1, 1, 1\right) \dotprod \left(-z\cos\left(\theta\right), -z\sin\left(\theta\right), z\right) d \theta dz = \int_{0}^{1} \int_{0}^{2\pi} \left(-z\cos\left(\theta\right) - z\sin\left(\theta\right) + z\right) d \theta dz = \int_{0}^{1} 2\pi z dz = 2\pi \frac{1}{2} = \pi}
     \end{subparag}
 
     \begin{subparag}{Paramétrisation du bord}


### PR DESCRIPTION
Dans le calcul de l'intégrale de surface, la variable $z$ était remplacée par la constante $2$ dans les deux premières composantes du vecteur. Bien que le résultat final de $\pi$ reste inchangé (car l'intégrale des fonctions sinus et cosinus sur $[0, 2\pi]$ est nulle), cette modification rend le calcul cohérent avec le vecteur normal défini précédemment.

Merci beaucoup pour tes notes ! 